### PR TITLE
add a argpars function to generator.py and an export module to extract the output maze in the specified format and size

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -1,0 +1,25 @@
+def exporter(result, output_format):
+    """
+    determines the output format:
+    """
+    if output_format == 'terminal':
+        terminal_report(result)
+    elif output_format == 'txt':
+        text_export(result)
+
+
+def terminal_report(result):
+    """
+    displays the maze in terminal
+    """
+    print(result)
+
+
+def text_export(result):
+    """
+    exports the maze as a text file in the same /src directory.
+    """
+    with open("2DMaze.txt", "w") as file:
+        file.write(result)
+    print('successfully wrote the file in 2DMaze.txt file')
+    

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,6 +1,26 @@
 from maze import Maze
+import argparse
 
-maze = Maze(20)
-maze.generate_maze()
-maze.print()
-print("Welcome to 2D maze")
+
+def parsing_arguments():
+    """
+    receives arguments from user to create the maze
+    size: is the size of the maze (default 20)
+    output_format: is the output format: pdf, txt, terminal (default terminal)
+    returns: arguments object with the arguments from user
+    """
+    parser = argparse.ArgumentParser(description="maze generator")
+    parser.add_argument('-o', '--output_format', choices=['pdf', 'txt', 'terminal'], 
+                        default='terminal', help='It specifies the output format')
+    parser.add_argument('-s', '--size', default=20, type=int, help='It specifies the size of the maze')
+    arguments = parser.parse_args()
+    return arguments
+
+
+if __name__ == '__main__':
+    print("Welcome to 2D Maze")
+    argument = parsing_arguments()
+    maze = Maze(argument.size)
+    maze.generate_maze()
+    maze.print(argument.output_format)
+    

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,5 +1,6 @@
 import random
 
+
 class Graph:
     def __init__(self, num_nodes):
         self.num_nodes = num_nodes
@@ -46,4 +47,4 @@ class Graph:
                 stack.pop()
 
         return spanning_tree
-
+    

--- a/src/maze.py
+++ b/src/maze.py
@@ -1,4 +1,6 @@
 from graph import Graph
+from export import exporter
+
 
 class Maze:
     def __init__(self, size):
@@ -34,29 +36,29 @@ class Maze:
         for i in range(0, self.graph.num_nodes):
             for j in range(0, self.graph.num_nodes):
                 if spanning_tree.has_edge(i, j):
-                    self.graph.remove_edge(i, j);
+                    self.graph.remove_edge(i, j)
                     
-    def print(self):
+    def print(self, output_format):
         result = ' '+('_ ' * (self.size-1))+'_\n'
         for i in range(self.size):
-            result+='|'
+            result += '|'
             for j in range(self.size):
                 node = self.nodes[i][j]
                 # check the floor (bottom wall)
                 if i < self.size-1 and self.graph.has_edge(node, self.nodes[i+1][j]):
-                    result+='_'
-                elif (i == self.size-1):
-                    result+='_'
+                    result += '_'
+                elif i == self.size-1:
+                    result += '_'
                 else:
-                    result+=' '
+                    result += ' '
 
                 # check the right wall
                 if j < self.size-1 and self.graph.has_edge(node, self.nodes[i][j+1]):
-                    result+='|'
+                    result += '|'
                 elif i < self.size-1 and j < self.size-1:
-                    result+=' '
+                    result += ' '
                 elif i == self.size-1 and j < self.size-1:
-                    result+='_'
-            result+='|\n'
-        print(result)
-
+                    result += '_'
+            result += '|\n'
+        exporter(result, output_format)
+        


### PR DESCRIPTION
I made a argparse function so the user can insert the size of the maze and output format (txt, pdf or display in terminal) in terminal by:
python3 generate.py -s 20 -o txt
defined an export module in which it exports the generated maze by the specified format.
also made some format change in code according to pip standard. 